### PR TITLE
Remove dependancy for vlucas/phpdotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Using composer:
 $ composer require paubox/paubox-php
 ```
 
+  Note: The examples below make use of [vlucas/phpdotenv](https://github.com/vlucas/phpdotenv).  Consult the project's instructions on how to install if you want to use `.env` files.  
+
 ### Getting Paubox API Credentials
 
 You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
 	"homepage" : "https://github.com/Paubox/paubox-php",
 	"license" : "Apache-2.0",
 	"require" : {
-		"nategood/httpful" : "*",
-		"vlucas/phpdotenv" : "3.4.0"
+		"nategood/httpful" : "*"
 	},
 	"require-dev" : {
 		"phpunit/phpunit" : "^5.7.9"


### PR DESCRIPTION
vlucas/phpdotenv is not actually used by this SDK.   It's a requirement for the example code in README.md  Since most frameworks and other libraries already use vlucas/phpdotenv, the better approach is to specify it's inclusion as a suggestion.