### PR TITLE
docs: update paubox.com/paubox.net links to current URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **NEW:** [Version 2 of the Paubox Email API SDK for PHP](https://github.com/Paubox/paubox-php/tree/sdk-generation/v2.0.0-beta) is available to beta test now. It includes code for newer features like bulk message sending, dynamic templates, and more. We will be deprecating the old in the near future.
 
-This is the official PHP wrapper for the [Paubox Email API](https://www.paubox.com/solutions/email-api). 
+This is the official PHP wrapper for the [Paubox Email API](https://www.paubox.com/products/paubox-email-api). 
 
 The Paubox Email API allows your application to send secure, HIPAA compliant email via Paubox and track deliveries and opens.
 The API wrapper also allows you to construct and send messages.
@@ -26,7 +26,7 @@ $ composer require paubox/paubox-php
 
 ### Getting Paubox API Credentials
 
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
 Once you have an account, follow the instructions on the Rest API dashboard to verify domain ownership and generate API credentials.
 


### PR DESCRIPTION
## Summary

Audits every `paubox.com` / `paubox.net` reference in this repo and rewrites legacy/broken URLs to their current canonical values. Only `README.md` was changed.

## Inventory & classification

| # | File | Line | URL | Classification |
|---|---|---|---|---|
| 1 | `README.md` | 7 | `https://www.paubox.com/solutions/email-api` | Marketing migration → rewritten |
| 2 | `README.md` | 29 | `https://www.paubox.com/join/see-pricing?unit=messages` | Marketing migration → rewritten |
| 3 | `src/Paubox.php` | 9 | `https://api.paubox.net/v1/` | Runtime API base URL, well-formed → **no change** |

**Counts:** 3 total matches → 2 rewrites, 1 leave-alone, 0 flags.

No `docs.paubox.com` URLs exist in this repo, so the legacy Swagger / anchor-fragment patterns from the brief had no work to do here. No `dist/`, `build/`, `vendor/`, `lib/` mirror, or phar artifacts present.

## Liveness check (pre-edit)

Run with `curl -sIL --max-time 15 -o /dev/null -w '%{http_code} %{url_effective} redirects=%{num_redirects}\n'`:

| URL | Final status | Final URL | Notes |
|---|---|---|---|
| `https://www.paubox.com/solutions/email-api` (legacy) | 200 | `https://www.paubox.com/products/paubox-email-api` | Redirects (2 hops) to canonical — confirms the rewrite |
| `https://www.paubox.com/join/see-pricing?unit=messages` (legacy) | **404** | (same) | Broken — rewrite required |
| `https://www.paubox.com/products/paubox-email-api` (target) | 200 | (same) | Direct |
| `https://www.paubox.com/pricing/paubox-email-api` (target) | 200 | (same) | Direct |

Post-edit re-check on the two targets in their new positions: both return `final_status=200`, `redirects=0`. Both canonical.

## Before / after

**`README.md:7`**
```diff
-This is the official PHP wrapper for the [Paubox Email API](https://www.paubox.com/solutions/email-api). 
+This is the official PHP wrapper for the [Paubox Email API](https://www.paubox.com/products/paubox-email-api). 
```

**`README.md:29`**
```diff
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
```

Query string (`?unit=messages`) dropped per the brief's strip-query-strings policy.

## Flagged items

None.

## Test plan

- [ ] Render `README.md` on the PR page; click both updated links and confirm they land on the intended pages.
- [ ] Re-run `curl -sIL https://www.paubox.com/products/paubox-email-api` and `https://www.paubox.com/pricing/paubox-email-api` — both should return final 200 with no redirect.
- [ ] Confirm `src/Paubox.php:9` (`api.paubox.net/v1/`) is unchanged.
- [ ] Confirm no other files were modified: `git diff master..docs/url-cleanup --stat` should show only `README.md` with `2 +/-2`.

Generated with [Claude Code](https://claude.com/claude-code)