### PR TITLE
Add Paubox Forms API support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Paubox PHP — Claude Code Guide
+
+## What this repo is
+
+PHP SDK for two Paubox APIs:
+- **Transactional Email** (`Paubox\Paubox`) — send HIPAA-compliant email, check delivery status
+- **Forms** (`Paubox\PauboxForms`) — retrieve form definitions, submit form responses
+
+## Install dependencies
+
+```bash
+composer install
+```
+
+## Run tests
+
+```bash
+vendor/bin/phpunit src/tests/PauboxTest.php
+vendor/bin/phpunit src/tests/PauboxFormsTest.php
+```
+
+Tests make real HTTP calls. Email tests require `PAUBOX_API_KEY` and `PAUBOX_API_USER` env vars. Forms tests require valid form UUIDs in the data providers.
+
+## Regenerate autoloader
+
+```bash
+composer dump-autoload
+```
+
+## Project layout
+
+```
+src/
+  Paubox.php            Email API client
+  PauboxForms.php       Forms API client
+  mail/                 Email data models (Message, Header, Content, Attachment, response types)
+  forms/                Forms data models (Form, FormSubmission, FormAttachment)
+  service/
+    ApiHelper.php       Thin httpful wrapper (callToAPIByGet, callToAPIByPost, callToAPIByPostWithResponse)
+  tests/
+    PauboxTest.php      Email API integration tests
+    PauboxFormsTest.php Forms API integration tests
+```
+
+## Key conventions
+
+- **Data models** live in `src/mail/` or `src/forms/`, use private properties with explicit getters/setters, no constructor args.
+- **Namespaces**: `Paubox\`, `Paubox\Mail\`, `Paubox\Forms\`, `Paubox\Service\` (see `composer.json` autoload).
+- **HTTP** is done through `Service\ApiHelper`. Pass `null` for `$auth_header` on unauthenticated endpoints — the helper skips the Authorization header automatically.
+- **Email API base URL**: `https://api.paubox.net/v1/{PAUBOX_API_USER}/` (auth: `Token token={PAUBOX_API_KEY}`)
+- **Forms API base URL**: `https://next.paubox.com` (no auth)
+- HTML content in emails is base64-encoded before sending; plain text is sent as-is.
+- `callToAPIByPostWithResponse()` returns the raw httpful response object (use `->code` and `->raw_body`); the other two helpers return only `->raw_body`.
+- PHPUnit version is `^5.7.9` — use `@expectedException` annotation, not `$this->expectException()`.
+
+## Environment variables (Email API only)
+
+| Variable          | Description                        |
+|-------------------|------------------------------------|
+| `PAUBOX_API_KEY`  | API key / token                    |
+| `PAUBOX_API_USER` | Endpoint name (subdomain segment)  |
+
+Load via `.env` + `vlucas/phpdotenv` or export directly in the shell before running tests.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ The API wrapper also allows you to construct and send messages.
 
 # Table of Contents
 * [Installation](#installation)
-*  [Usage](#usage)
-*  [Contributing](#contributing)
-*  [License](#license)
+* [Usage](#usage)
+  * [Sending messages](#sending-messages)
+  * [Allowing non-TLS message delivery](#allowing-non-tls-message-delivery)
+  * [Forcing Secure Notifications](#forcing-secure-notifications)
+  * [Adding Attachments and Additional Headers](#adding-attachments-and-additional-headers)
+  * [Checking Email Dispositions](#checking-email-dispositions)
+  * [Paubox Forms](#paubox-forms)
+* [Contributing](#contributing)
+* [License](#license)
 
 <a name="#installation"></a>
 ## Installation
@@ -222,6 +228,69 @@ $paubox = new Paubox\Paubox();
 
 $resp = $paubox->getEmailDisposition('SOURCE_TRACKING_ID');
 print_r($resp);
+```
+
+<a name="#paubox-forms"></a>
+## Paubox Forms
+
+`PauboxForms` provides access to the [Paubox Forms API](https://docs.paubox.com/forms/get-form). No API credentials are required — these endpoints are unauthenticated.
+
+### Getting a form
+
+Retrieve the full definition of a form (HTML, JSON schema, CSS, and metadata) by its UUID.
+
+```php
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+$forms = new Paubox\PauboxForms();
+
+$form = $forms->getForm('YOUR-FORM-UUID');
+echo $form->title;       // "Patient Intake Form"
+echo $form->form_html;   // "<form>...</form>"
+print_r($form->form_json);
+```
+
+### Submitting a form
+
+Build a `FormSubmission` with `form_data` matching the form's field schema and call `submitForm`. Returns `true` on success; throws an exception on failure.
+
+```php
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+$forms = new Paubox\PauboxForms();
+
+$submission = new Paubox\Forms\FormSubmission();
+$submission->setFormData([
+    'first_name' => 'Jane',
+    'last_name'  => 'Smith',
+    'email'      => 'jane@example.com',
+]);
+
+$result = $forms->submitForm('YOUR-FORM-UUID', $submission);
+// $result === true on success
+```
+
+### Submitting a form with file attachments
+
+Attachments must be base64-encoded. Maximum total request size is 250 MB.
+
+```php
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+$forms = new Paubox\PauboxForms();
+
+$attachment = new Paubox\Forms\FormAttachment();
+$attachment->setName('consent.pdf');
+$attachment->setContent(base64_encode(file_get_contents('/path/to/consent.pdf')));
+
+$submission = new Paubox\Forms\FormSubmission();
+$submission->setFormData(['first_name' => 'Jane', 'last_name' => 'Smith']);
+$submission->setAttachments([$attachment]);
+
+$result = $forms->submitForm('YOUR-FORM-UUID', $submission);
 ```
 
 <a name="#contributing"></a>

--- a/api.md
+++ b/api.md
@@ -1,0 +1,136 @@
+# Paubox PHP API Reference
+
+## Email API (`Paubox\Paubox`)
+
+Base URL: `https://api.paubox.net/v1/{PAUBOX_API_USER}/`  
+Authentication: `Authorization: Token token={PAUBOX_API_KEY}`
+
+---
+
+### `sendMessage(Message $message): object`
+
+Sends a HIPAA-compliant email.
+
+**Parameters**
+
+| Class | Method | Type | Required | Description |
+|---|---|---|---|---|
+| `Message` | `setRecipients($array)` | string[] | Yes | To addresses |
+| `Message` | `setCc($array)` | string[] | No | CC addresses |
+| `Message` | `setBcc($array)` | string[] | No | BCC addresses |
+| `Message` | `setHeader(Header $h)` | `Header` | Yes | Subject, From, Reply-To |
+| `Message` | `setContent(Content $c)` | `Content` | Yes | Plain/HTML body |
+| `Message` | `setAttachments($array)` | `Attachment[]` | No | File attachments |
+| `Message` | `setAllowNonTLS($bool)` | bool | No | Allow non-TLS delivery (default false) |
+| `Message` | `setForceSecureNotification($str)` | `"true"\|"false"` | No | Force portal notification |
+| `Header` | `setSubject($str)` | string | Yes | Email subject |
+| `Header` | `setFrom($str)` | string | Yes | Sender address |
+| `Header` | `setReplyTo($str)` | string | No | Reply-To address |
+| `Content` | `setPlainText($str)` | string | No | Plain text body |
+| `Content` | `setHtmlText($str)` | string | No | HTML body (base64-encoded automatically) |
+| `Attachment` | `setFileName($str)` | string | Yes | File name |
+| `Attachment` | `setContentType($str)` | string | Yes | MIME type |
+| `Attachment` | `setContent($str)` | string | Yes | Base64-encoded file content |
+
+**Returns** `stdClass` with:
+```
+sourceTrackingId  string   Use this to check delivery status
+data              object
+errors            array
+```
+
+**Throws** `\Exception` if `Header` or `Content` is null, or if the API returns an unparseable response.
+
+---
+
+### `getEmailDisposition(string $sourceTrackingId): object`
+
+Checks the delivery and open status of a sent message.
+
+**Returns** `stdClass` with:
+```
+sourceTrackingId  string
+data
+  message
+    id                  string
+    message_deliveries  array
+      recipient         string
+      status
+        deliveryStatus  string
+        deliveryTime    string
+        openedStatus    string
+        openedTime      string
+errors  array
+```
+
+**Throws** `\Exception` if the API returns an unparseable response.
+
+---
+
+## Forms API (`Paubox\PauboxForms`)
+
+Base URL: `https://next.paubox.com`  
+Authentication: None
+
+---
+
+### `getForm(string $formId): stdClass`
+
+Retrieves the full definition of a form by UUID.
+
+**Endpoint:** `GET /public/form_data/{form_id}`
+
+**Parameters**
+
+| Name | Type | Description |
+|---|---|---|
+| `$formId` | string (UUID) | UUID of the form to retrieve |
+
+**Returns** `stdClass` with:
+```
+id                          string (UUID)
+title                       string
+description                 string|null
+form_html                   string|null   Rendered HTML of the form
+form_json                   object|null   Field schema
+form_css                    string|null   Scoped CSS
+vanity_url                  string|null
+version                     int
+active                      bool
+customer_id                 int
+signable                    bool
+signature_confirmation_label string|null
+submission_count            int
+type                        string|null
+deleted                     bool
+archived                    bool
+created_at                  string (ISO 8601)
+updated_at                  string (ISO 8601)
+```
+
+**Throws** `\Exception` if the form is not found or the response is invalid.
+
+---
+
+### `submitForm(string $formId, FormSubmission $submission): true`
+
+Submits a respondent's answers for a form.
+
+**Endpoint:** `POST /api/forms/{form_id}/submissions`
+
+Maximum request size: **250 MB** (to support file attachments).
+
+**Parameters**
+
+| Class | Method | Type | Required | Description |
+|---|---|---|---|---|
+| `FormSubmission` | `setFormData($array)` | array | Yes | Key-value pairs matching the form's `form_json` schema |
+| `FormSubmission` | `setAttachments($array)` | `FormAttachment[]` | No | File attachments |
+| `FormAttachment` | `setName($str)` | string | Yes | Filename |
+| `FormAttachment` | `setContent($str)` | string | Yes | Base64-encoded file content |
+
+**Returns** `true` on success (HTTP 201).
+
+**Throws** `\Exception` on failure:
+- HTTP 400 — `form_data` field is missing
+- HTTP 404 — form not found

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"psr-4" : {
 			"Paubox\\" : "src/",
 			"Paubox\\Mail\\" : "src/mail/",
+			"Paubox\\Forms\\" : "src/forms/",
 			"Paubox\\Service\\" : "src/service/"
 		}
 	},

--- a/src/PauboxForms.php
+++ b/src/PauboxForms.php
@@ -1,0 +1,51 @@
+<?php
+namespace Paubox;
+
+class PauboxForms
+{
+    private $baseUrl = "https://next.paubox.com";
+
+    public function getForm($formId)
+    {
+        $api = new Service\ApiHelper();
+        $url = $this->baseUrl . "/public/form_data/" . $formId;
+        $resp = $api->callToAPIByGet($url, null);
+        $form = json_decode($resp);
+        if (is_null($form) || !isset($form->id)) {
+            throw new \Exception("Form not found or invalid response.");
+        }
+        return $form;
+    }
+
+    public function submitForm($formId, Forms\FormSubmission $submission)
+    {
+        if (is_null($submission->getFormData())) {
+            throw new \Exception("FormSubmission form_data cannot be null.");
+        }
+
+        $body = ['form_data' => $submission->getFormData()];
+
+        $attachments = $submission->getAttachments();
+        if (!empty($attachments)) {
+            $jsonAttachments = [];
+            foreach ($attachments as $att) {
+                $jsonAttachments[] = [
+                    'name'    => $att->getName(),
+                    'content' => $att->getContent()
+                ];
+            }
+            $body['attachments'] = $jsonAttachments;
+        }
+
+        $api = new Service\ApiHelper();
+        $url = $this->baseUrl . "/api/forms/" . $formId . "/submissions";
+        $response = $api->callToAPIByPostWithResponse($url, null, $body);
+
+        if ($response->code !== 201) {
+            throw new \Exception("Form submission failed: HTTP " . $response->code . " - " . $response->raw_body);
+        }
+
+        return true;
+    }
+}
+?>

--- a/src/forms/Form.php
+++ b/src/forms/Form.php
@@ -1,0 +1,79 @@
+<?php
+namespace Paubox\Forms;
+
+class Form
+{
+    private $id;
+    private $title;
+    private $description;
+    private $formHtml;
+    private $formJson;
+    private $formCss;
+    private $vanityUrl;
+    private $version;
+    private $active;
+    private $customerId;
+    private $signable;
+    private $signatureConfirmationLabel;
+    private $submissionCount;
+    private $type;
+    private $deleted;
+    private $archived;
+    private $createdAt;
+    private $updatedAt;
+
+    public function getId() { return $this->id; }
+    public function setId($id) { $this->id = $id; }
+
+    public function getTitle() { return $this->title; }
+    public function setTitle($title) { $this->title = $title; }
+
+    public function getDescription() { return $this->description; }
+    public function setDescription($description) { $this->description = $description; }
+
+    public function getFormHtml() { return $this->formHtml; }
+    public function setFormHtml($formHtml) { $this->formHtml = $formHtml; }
+
+    public function getFormJson() { return $this->formJson; }
+    public function setFormJson($formJson) { $this->formJson = $formJson; }
+
+    public function getFormCss() { return $this->formCss; }
+    public function setFormCss($formCss) { $this->formCss = $formCss; }
+
+    public function getVanityUrl() { return $this->vanityUrl; }
+    public function setVanityUrl($vanityUrl) { $this->vanityUrl = $vanityUrl; }
+
+    public function getVersion() { return $this->version; }
+    public function setVersion($version) { $this->version = $version; }
+
+    public function getActive() { return $this->active; }
+    public function setActive($active) { $this->active = $active; }
+
+    public function getCustomerId() { return $this->customerId; }
+    public function setCustomerId($customerId) { $this->customerId = $customerId; }
+
+    public function getSignable() { return $this->signable; }
+    public function setSignable($signable) { $this->signable = $signable; }
+
+    public function getSignatureConfirmationLabel() { return $this->signatureConfirmationLabel; }
+    public function setSignatureConfirmationLabel($label) { $this->signatureConfirmationLabel = $label; }
+
+    public function getSubmissionCount() { return $this->submissionCount; }
+    public function setSubmissionCount($submissionCount) { $this->submissionCount = $submissionCount; }
+
+    public function getType() { return $this->type; }
+    public function setType($type) { $this->type = $type; }
+
+    public function getDeleted() { return $this->deleted; }
+    public function setDeleted($deleted) { $this->deleted = $deleted; }
+
+    public function getArchived() { return $this->archived; }
+    public function setArchived($archived) { $this->archived = $archived; }
+
+    public function getCreatedAt() { return $this->createdAt; }
+    public function setCreatedAt($createdAt) { $this->createdAt = $createdAt; }
+
+    public function getUpdatedAt() { return $this->updatedAt; }
+    public function setUpdatedAt($updatedAt) { $this->updatedAt = $updatedAt; }
+}
+?>

--- a/src/forms/FormAttachment.php
+++ b/src/forms/FormAttachment.php
@@ -1,0 +1,15 @@
+<?php
+namespace Paubox\Forms;
+
+class FormAttachment
+{
+    private $name;
+    private $content;
+
+    public function getName() { return $this->name; }
+    public function setName($name) { $this->name = $name; }
+
+    public function getContent() { return $this->content; }
+    public function setContent($content) { $this->content = $content; }
+}
+?>

--- a/src/forms/FormSubmission.php
+++ b/src/forms/FormSubmission.php
@@ -1,0 +1,15 @@
+<?php
+namespace Paubox\Forms;
+
+class FormSubmission
+{
+    private $formData;
+    private $attachments = [];
+
+    public function getFormData() { return $this->formData; }
+    public function setFormData($formData) { $this->formData = $formData; }
+
+    public function getAttachments() { return $this->attachments; }
+    public function setAttachments($attachments) { $this->attachments = $attachments; }
+}
+?>

--- a/src/service/ApiHelper.php
+++ b/src/service/ApiHelper.php
@@ -33,6 +33,21 @@ class ApiHelper
 
         return $response->raw_body;
     }
+
+    function callToAPIByPostWithResponse($uri, $auth_header, $request_body)
+    {
+        $header['accept'] = "application/json";
+        if (null != $auth_header) {
+            $header['Authorization'] = $auth_header;
+        }
+
+        $response = \Httpful\Request::post($uri)->sendsJson()
+            ->addHeaders($header)
+            ->body($request_body)
+            ->send();
+
+        return $response;
+    }
 }
 
 ?>

--- a/src/tests/PauboxFormsTest.php
+++ b/src/tests/PauboxFormsTest.php
@@ -1,0 +1,100 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use Paubox\PauboxForms;
+use Paubox\Forms\FormSubmission;
+use Paubox\Forms\FormAttachment;
+
+require_once dirname(dirname(__DIR__)) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . "/PauboxForms.php";
+require_once dirname(__DIR__) . "/forms/Form.php";
+require_once dirname(__DIR__) . "/forms/FormSubmission.php";
+require_once dirname(__DIR__) . "/forms/FormAttachment.php";
+
+class PauboxFormsTest extends TestCase
+{
+    private $forms;
+
+    public function setUp()
+    {
+        $this->forms = new PauboxForms();
+    }
+
+    public function tearDown()
+    {
+        $this->forms = null;
+        parent::tearDown();
+    }
+
+    public function getFormDataProvider_Success()
+    {
+        return [
+            ['YOUR-VALID-FORM-UUID-HERE']
+        ];
+    }
+
+    public function getFormDataProvider_NotFound()
+    {
+        return [
+            ['00000000-0000-0000-0000-000000000000']
+        ];
+    }
+
+    /**
+     * @dataProvider getFormDataProvider_Success
+     */
+    public function testGetForm_ReturnSuccess($formId)
+    {
+        $form = $this->forms->getForm($formId);
+        if (is_null($form) || !isset($form->id) || !isset($form->title)) {
+            $this->fail('Expected form with id and title');
+        } else {
+            $this->assertTrue(true);
+        }
+    }
+
+    /**
+     * @dataProvider getFormDataProvider_NotFound
+     * @expectedException \Exception
+     */
+    public function testGetForm_ReturnNotFound($formId)
+    {
+        $this->forms->getForm($formId);
+    }
+
+    public function submitFormDataProvider_Success()
+    {
+        return [
+            ['YOUR-VALID-FORM-UUID-HERE', ['first_name' => 'Jane', 'last_name' => 'Smith']]
+        ];
+    }
+
+    public function submitFormDataProvider_Error()
+    {
+        return [
+            ['00000000-0000-0000-0000-000000000000', ['first_name' => 'Jane']]
+        ];
+    }
+
+    /**
+     * @dataProvider submitFormDataProvider_Success
+     */
+    public function testSubmitForm_ReturnSuccess($formId, $formData)
+    {
+        $submission = new FormSubmission();
+        $submission->setFormData($formData);
+        $result = $this->forms->submitForm($formId, $submission);
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @dataProvider submitFormDataProvider_Error
+     * @expectedException \Exception
+     */
+    public function testSubmitForm_ReturnError($formId, $formData)
+    {
+        $submission = new FormSubmission();
+        $submission->setFormData($formData);
+        $this->forms->submitForm($formId, $submission);
+    }
+}
+?>


### PR DESCRIPTION
Introduces PauboxForms client with getForm() and submitForm() methods
targeting the unauthenticated https://next.paubox.com Forms endpoints.

- src/PauboxForms.php: new client class
- src/forms/Form.php, FormSubmission.php, FormAttachment.php: data models
- src/service/ApiHelper.php: add callToAPIByPostWithResponse() for status-code access
- src/tests/PauboxFormsTest.php: integration test skeleton
- composer.json: register Paubox\\Forms\\ namespace

https://claude.ai/code/session_01VsfpPRETUhrM1VFWeqrGPS