### PR TITLE
Add Paubox Forms API support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ src/
 - **Namespaces**: `Paubox\`, `Paubox\Mail\`, `Paubox\Forms\`, `Paubox\Service\` (see `composer.json` autoload).
 - **HTTP** is done through `Service\ApiHelper`. Pass `null` for `$auth_header` on unauthenticated endpoints — the helper skips the Authorization header automatically.
 - **Email API base URL**: `https://api.paubox.net/v1/{PAUBOX_API_USER}/` (auth: `Token token={PAUBOX_API_KEY}`)
-- **Forms API base URL**: `https://next.paubox.com` (no auth)
+- **Forms API base URL**: `https://apx.paubox.com/forms` (no auth)
 - HTML content in emails is base64-encoded before sending; plain text is sent as-is.
 - `callToAPIByPostWithResponse()` returns the raw httpful response object (use `->code` and `->raw_body`); the other two helpers return only `->raw_body`.
 - PHPUnit version is `^5.7.9` — use `@expectedException` annotation, not `$this->expectException()`.

--- a/api.md
+++ b/api.md
@@ -69,7 +69,7 @@ errors  array
 
 ## Forms API (`Paubox\PauboxForms`)
 
-Base URL: `https://next.paubox.com`  
+Base URL: `https://apx.paubox.com/forms`  
 Authentication: None
 
 ---

--- a/src/PauboxForms.php
+++ b/src/PauboxForms.php
@@ -3,7 +3,7 @@ namespace Paubox;
 
 class PauboxForms
 {
-    private $baseUrl = "https://next.paubox.com";
+    private $baseUrl = "https://apx.paubox.com/forms";
 
     public function getForm($formId)
     {


### PR DESCRIPTION
## Summary

- Adds `PauboxForms` client with `getForm()` and `submitForm()` methods targeting the new `https://apx.paubox.com/forms` endpoints (no authentication required)
- Adds `Form`, `FormSubmission`, and `FormAttachment` data models under `src/forms/`
- Extends `ApiHelper` with `callToAPIByPostWithResponse()` to expose HTTP status codes (needed since a successful form submission returns 201 with no body)
- Registers the `Paubox\Forms\` namespace in `composer.json`
- Adds integration test skeleton in `src/tests/PauboxFormsTest.php` (replace `YOUR-VALID-FORM-UUID-HERE` with a real form UUID before running)
- Updates `README.md` with Forms usage examples (get form, submit form, submit with attachments)
- Adds `CLAUDE.md` with project layout, conventions, and build/test commands
- Adds `api.md` with full API reference for both the Email and Forms clients

## Test plan

- [ ] Replace `YOUR-VALID-FORM-UUID-HERE` in `src/tests/PauboxFormsTest.php` with a real form UUID
- [ ] Run `vendor/bin/phpunit src/tests/PauboxFormsTest.php` and confirm all four tests pass
- [ ] Run `vendor/bin/phpunit src/tests/PauboxTest.php` and confirm existing email tests are unaffected
- [ ] Verify `composer dump-autoload` completes without errors

https://claude.ai/code/session_01VsfpPRETUhrM1VFWeqrGPS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsfpPRETUhrM1VFWeqrGPS)_